### PR TITLE
Remove the option for customized pycodestyle configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ shellcheck = off
 
 ## Customizing pycodestyle configuration
 
-Different projects have different coding styles. You can create a file `pycodestyle.ini` in the
-project directory, as shown below.
+Different projects have different coding styles. Pycodestyle reads per-project configuration from
+tox.ini or setup.cfg as described at https://pycodestyle.pycqa.org/en/latest/intro.html so you can
+use those files to customize the style for your project, e.g.
 
 ```
 [pycodestyle]

--- a/codecheck/code_check.py
+++ b/codecheck/code_check.py
@@ -62,12 +62,10 @@ def print_stats(description: str, d: Dict[str, int]) -> None:
 
 class CodeCheckConfig:
     mypy_config_path: str
-    pycodestyle_config_path: str
     disabled_check_types: Set[str]
 
     def __init__(self) -> None:
         self.mypy_config_path = 'mypy.ini'
-        self.pycodestyle_config_path = 'pycodestyle.ini'
         self.disabled_check_types = set()
 
     def load(self, file_path: str) -> None:
@@ -78,14 +76,9 @@ class CodeCheckConfig:
         if 'default' in sections:
             default_section = parsed_ini['default']
 
-            # TODO: deduplicate this pattern.
             mypy_config_path = default_section.get('mypy_config')
             if mypy_config_path is not None:
                 self.mypy_config_path = mypy_config_path
-
-            pycodestyle_config_path = default_section.get('pycodestyle_config')
-            if pycodestyle_config_path is not None:
-                self.pycodestyle_config_path = pycodestyle_config_path
 
         if 'checks' in sections:
             checks_section = parsed_ini['checks']
@@ -186,8 +179,7 @@ class CodeChecker:
             ]
             append_file_path = False
         elif check_type == 'pycodestyle':
-            args = [self.args.python_interpreter, '-m', 'pycodestyle',
-                    f'--config={self.config.pycodestyle_config_path}']
+            args = [self.args.python_interpreter, '-m', 'pycodestyle']
         elif check_type == 'unittest':
             append_file_path = False
             rel_path_components = os.path.splitext(rel_path)[0].split('/')

--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,7 @@
 # or implied. See the License for the specific language governing permissions and limitations
 # under the License.
 
+# Pycodestyle looks at tox.ini to get the project-specific style.
+# https://pycodestyle.pycqa.org/en/latest/intro.html
 [pycodestyle]
 max-line-length = 100


### PR DESCRIPTION
When using codecheck in the CI for https://github.com/yugabyte/compiler-identification, somehow the custom pycodestyle.ini configuration file did not work. The tox.ini technique seems to always work, so making that the default approach for customizing the code style.